### PR TITLE
Implement WhatsApp training attendance automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+
+# Local data exports
+out/
+data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
-# participa
+# Participa WhatsApp Training Attendance Bot
+
+This repository contains a configurable WhatsApp chatbot that reads a Google Calendar for upcoming training events, posts poll messages in a WhatsApp chat, and exports the daily attendance results to CSV.
+
+## Features
+
+- **Google Calendar integration** – reads a service account calendar and filters events by a configurable title pattern.
+- **WhatsApp poll automation** – posts a poll for every training session using the WhatsApp Cloud API.
+- **Attendance exports** – fetches votes at the end of the day and writes a CSV summary mapped to player names.
+- **Configurable** – chat id, calendar configuration, filter pattern, poll options, and player phone mapping live in a YAML config file.
+
+## Project layout
+
+```
+config.sample.yaml         # Example configuration file
+src/participa/             # Python package containing the bot
+  ├── bot.py               # High-level orchestration
+  ├── calendar.py          # Google Calendar wrapper
+  ├── cli.py               # Command line entry point
+  ├── config.py            # YAML configuration loader
+  ├── poll_manager.py      # Poll persistence and CSV export
+  └── whatsapp.py          # WhatsApp Cloud API client
+```
+
+## Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **Create a configuration file**
+
+   Copy `config.sample.yaml` to `config.yaml` and fill in your credentials:
+
+   - `calendar.credentials_path`: path to the Google service account JSON file.
+   - `calendar.filter_pattern`: regular expression used to select training events.
+   - `whatsapp` section: details for the WhatsApp Cloud API (token, phone number id, and chat id).
+   - `players`: mapping of WhatsApp phone numbers (international format) to player names.
+
+3. **Run the bot**
+
+   Send polls for today:
+
+   ```bash
+   python -m participa.cli send-polls
+   ```
+
+   Collect results for today and export to CSV:
+
+   ```bash
+   python -m participa.cli collect-results
+   ```
+
+   Use `--date YYYY-MM-DD` to target a different day and `--config path/to/file.yaml` to use a custom configuration file.
+
+## Requirements
+
+- Python 3.11+
+- Google Calendar service account with read access to the calendar containing the training events.
+- WhatsApp Cloud API credentials with permission to send polls to the configured chat.
+
+## Notes
+
+- Poll metadata is stored in `data/polls_YYYY-MM-DD.json` (customizable via `storage_dir`).
+- Daily CSV exports are saved to `out/attendance_YYYYMMDD.csv` (customizable via `results_dir`).
+- Retrieving poll votes requires enabling the appropriate fields in the WhatsApp Graph API and may require webhook subscriptions depending on your account tier.
+
+## License
+
+This project is provided as-is without warranty.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,0 +1,23 @@
+calendar:
+  calendar_id: "primary"
+  credentials_path: "~/service_account.json"
+  filter_pattern: "Training"
+
+whatsapp:
+  token: "YOUR_WHATSAPP_TOKEN"
+  phone_number_id: "1234567890"
+  chat_id: "15551234567"
+  graph_api_version: "v19.0"
+
+players:
+  "+15551230001": "Alice"
+  "+15551230002": "Bob"
+  "+15551230003": "Charlie"
+
+poll_options:
+  - "✅ Attending"
+  - "❌ Not attending"
+  - "❓ Maybe"
+
+storage_dir: "./data"
+results_dir: "./out"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+google-api-python-client>=2.127.0
+google-auth>=2.29.0
+PyYAML>=6.0.1
+requests>=2.31.0

--- a/src/participa/__init__.py
+++ b/src/participa/__init__.py
@@ -1,0 +1,5 @@
+"""Participa WhatsApp attendance bot package."""
+
+from .bot import TrainingAttendanceBot, load_config
+
+__all__ = ["TrainingAttendanceBot", "load_config"]

--- a/src/participa/bot.py
+++ b/src/participa/bot.py
@@ -1,0 +1,79 @@
+"""High level orchestration for the training attendance bot."""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .calendar import GoogleCalendarClient, TrainingEvent
+from .config import BotConfig, load_config
+from .poll_manager import (
+    PollStorage,
+    StoredPoll,
+    aggregate_votes,
+    export_votes_to_csv,
+)
+from .whatsapp import WhatsAppPollClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TrainingAttendanceBot:
+    """Coordinates calendar lookups, poll sending, and vote aggregation."""
+
+    def __init__(
+        self,
+        config: BotConfig,
+        calendar_client: Optional[GoogleCalendarClient] = None,
+        whatsapp_client: Optional[WhatsAppPollClient] = None,
+        storage: Optional[PollStorage] = None,
+    ) -> None:
+        self.config = config
+        self.calendar = calendar_client or GoogleCalendarClient(config.calendar)
+        self.whatsapp = whatsapp_client or WhatsAppPollClient(config)
+        self.storage = storage or PollStorage(config)
+
+    def send_daily_polls(self, date: Optional[dt.date] = None) -> List[StoredPoll]:
+        """Create a WhatsApp poll for each training event on the given date."""
+        events = self._fetch_events(date)
+        stored_polls: List[StoredPoll] = []
+        for event in events:
+            question = self._format_question(event)
+            poll = self.whatsapp.send_poll(question, self.config.poll_options)
+            stored = StoredPoll.from_event(event, poll)
+            self.storage.record_poll(event, poll)
+            stored_polls.append(stored)
+            LOGGER.info(
+                "Created poll %s for event %s", poll.id, event.title
+            )
+        return stored_polls
+
+    def collect_attendance(self, date: Optional[dt.date] = None) -> Path:
+        """Collect poll votes and write them to a CSV file."""
+        if date is None:
+            date = dt.date.today()
+        polls = self.storage.load_polls(date)
+        rows: List[dict] = []
+        for poll in polls:
+            votes = self.whatsapp.fetch_poll_votes(poll.message_id)
+            rows.extend(aggregate_votes(poll, votes, self.config.players))
+        if not rows:
+            LOGGER.warning("No poll responses found for %s", date)
+        csv_path = export_votes_to_csv(self.config, date, rows)
+        LOGGER.info("Attendance exported to %s", csv_path)
+        return csv_path
+
+    def _fetch_events(self, date: Optional[dt.date]) -> Iterable[TrainingEvent]:
+        events = self.calendar.fetch_training_events(date)
+        if not events:
+            LOGGER.info("No training events found for %s", date or dt.date.today())
+        return events
+
+    @staticmethod
+    def _format_question(event: TrainingEvent) -> str:
+        start_time = event.start.strftime("%H:%M")
+        return f"{event.title} at {start_time} — will you attend?"
+
+
+__all__ = ["TrainingAttendanceBot", "load_config"]

--- a/src/participa/calendar.py
+++ b/src/participa/calendar.py
@@ -1,0 +1,95 @@
+"""Google Calendar utilities for retrieving training sessions."""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from google.oauth2.service_account import Credentials
+from googleapiclient.discovery import build
+
+from .config import CalendarConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class TrainingEvent:
+    """Representation of a single training event."""
+
+    id: str
+    title: str
+    start: dt.datetime
+    end: dt.datetime
+    location: str | None = None
+
+    @property
+    def date_key(self) -> str:
+        return self.start.strftime("%Y-%m-%d")
+
+
+class GoogleCalendarClient:
+    """Thin wrapper around the Google Calendar API."""
+
+    def __init__(self, config: CalendarConfig) -> None:
+        scopes = ["https://www.googleapis.com/auth/calendar.readonly"]
+        self._credentials = Credentials.from_service_account_file(
+            str(config.credentials_path), scopes=scopes
+        )
+        self._calendar_id = config.calendar_id
+        self._pattern = re.compile(config.filter_pattern, re.IGNORECASE)
+
+    def fetch_training_events(
+        self, date: dt.date | None = None
+    ) -> List[TrainingEvent]:
+        """Fetch training events for the provided date."""
+        if date is None:
+            date = dt.date.today()
+
+        start = dt.datetime.combine(date, dt.time.min, tzinfo=dt.timezone.utc)
+        end = dt.datetime.combine(date, dt.time.max, tzinfo=dt.timezone.utc)
+
+        service = build("calendar", "v3", credentials=self._credentials)
+        events = (
+            service.events()
+            .list(
+                calendarId=self._calendar_id,
+                timeMin=start.isoformat(),
+                timeMax=end.isoformat(),
+                singleEvents=True,
+                orderBy="startTime",
+            )
+            .execute()
+            .get("items", [])
+        )
+
+        return list(self._parse_events(events))
+
+    def _parse_events(self, raw_events: Iterable[dict]) -> Iterable[TrainingEvent]:
+        for entry in raw_events:
+            summary = entry.get("summary", "")
+            if not self._pattern.search(summary):
+                LOGGER.debug("Ignoring event '%s'", summary)
+                continue
+
+            start_raw = entry.get("start", {}).get("dateTime")
+            end_raw = entry.get("end", {}).get("dateTime")
+            if not start_raw or not end_raw:
+                LOGGER.warning("Event '%s' missing dateTime information", summary)
+                continue
+
+            start = dt.datetime.fromisoformat(start_raw)
+            end = dt.datetime.fromisoformat(end_raw)
+
+            yield TrainingEvent(
+                id=str(entry.get("id")),
+                title=summary,
+                start=start,
+                end=end,
+                location=entry.get("location"),
+            )
+
+
+__all__ = ["GoogleCalendarClient", "TrainingEvent"]

--- a/src/participa/cli.py
+++ b/src/participa/cli.py
@@ -1,0 +1,63 @@
+"""Command line interface for the training attendance bot."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+from pathlib import Path
+
+from .bot import TrainingAttendanceBot, load_config
+
+
+def _parse_date(value: str | None) -> dt.date | None:
+    if value is None:
+        return None
+    return dt.datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="WhatsApp attendance bot")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.yaml"),
+        help="Path to the YAML configuration file",
+    )
+    parser.add_argument(
+        "--date",
+        type=str,
+        help="Target date in YYYY-MM-DD. Defaults to today.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("send-polls", help="Send polls for training sessions")
+    subparsers.add_parser(
+        "collect-results", help="Collect poll votes and write a CSV report"
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    config = load_config(args.config)
+    bot = TrainingAttendanceBot(config)
+    date = _parse_date(args.date)
+
+    if args.command == "send-polls":
+        bot.send_daily_polls(date)
+    elif args.command == "collect-results":
+        bot.collect_attendance(date)
+    else:  # pragma: no cover - argparse enforces valid values
+        parser.error(f"Unknown command {args.command}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/participa/config.py
+++ b/src/participa/config.py
@@ -1,0 +1,144 @@
+"""Configuration handling for the Participa WhatsApp attendance bot."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Sequence
+
+import yaml
+
+
+@dataclass(slots=True)
+class CalendarConfig:
+    """Google Calendar connection details."""
+
+    calendar_id: str
+    credentials_path: Path
+    filter_pattern: str = ".*"
+
+
+@dataclass(slots=True)
+class WhatsAppConfig:
+    """Configuration required to communicate with the WhatsApp Cloud API."""
+
+    token: str
+    phone_number_id: str
+    chat_id: str
+    graph_api_version: str = "v19.0"
+
+
+@dataclass(slots=True)
+class BotConfig:
+    """Top level configuration for the attendance bot."""
+
+    calendar: CalendarConfig
+    whatsapp: WhatsAppConfig
+    players: Mapping[str, str] = field(default_factory=dict)
+    poll_options: Sequence[str] = field(
+        default_factory=lambda: (
+            "✅ Attending",
+            "❌ Not attending",
+            "❓ Maybe",
+        )
+    )
+    storage_dir: Path = Path("data")
+    results_dir: Path = Path("out")
+
+    def ensure_directories(self) -> None:
+        """Create the storage directories if they do not exist."""
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self.results_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _expand_path(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _load_calendar_config(raw: Mapping[str, object]) -> CalendarConfig:
+    try:
+        calendar_id = raw["calendar_id"]
+        credentials = raw["credentials_path"]
+    except KeyError as exc:  # pragma: no cover - explicit failure path
+        raise ValueError("calendar configuration requires 'calendar_id' and 'credentials_path'") from exc
+
+    return CalendarConfig(
+        calendar_id=str(calendar_id),
+        credentials_path=_expand_path(credentials),
+        filter_pattern=str(raw.get("filter_pattern", ".*")),
+    )
+
+
+def _load_whatsapp_config(raw: Mapping[str, object]) -> WhatsAppConfig:
+    required = {"token", "phone_number_id", "chat_id"}
+    missing = required.difference(raw)
+    if missing:  # pragma: no cover - explicit failure path
+        raise ValueError(f"whatsapp configuration missing keys: {', '.join(sorted(missing))}")
+
+    return WhatsAppConfig(
+        token=str(raw["token"]),
+        phone_number_id=str(raw["phone_number_id"]),
+        chat_id=str(raw["chat_id"]),
+        graph_api_version=str(raw.get("graph_api_version", "v19.0")),
+    )
+
+
+def _load_players(raw: Mapping[str, object] | Iterable[Mapping[str, object]]) -> Dict[str, str]:
+    players: Dict[str, str] = {}
+    if isinstance(raw, Mapping):
+        for phone, name in raw.items():
+            players[str(phone)] = str(name)
+        return players
+
+    for entry in raw:
+        phone = entry.get("phone")
+        name = entry.get("name")
+        if not phone or not name:
+            raise ValueError("player entries must define 'phone' and 'name'")
+        players[str(phone)] = str(name)
+    return players
+
+
+def load_config(path: str | Path) -> BotConfig:
+    """Load bot configuration from a YAML file."""
+    with Path(path).expanduser().open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle)
+
+    if not isinstance(payload, Mapping):  # pragma: no cover - defensive
+        raise ValueError("configuration file must contain a mapping")
+
+    calendar = _load_calendar_config(payload.get("calendar", {}))
+    whatsapp = _load_whatsapp_config(payload.get("whatsapp", {}))
+    players_raw = payload.get("players", {})
+    players = _load_players(players_raw)
+
+    poll_options = payload.get("poll_options")
+    if poll_options is None:
+        poll_options_seq: Sequence[str] = (
+            "✅ Attending",
+            "❌ Not attending",
+            "❓ Maybe",
+        )
+    else:
+        poll_options_seq = tuple(str(option) for option in poll_options)
+
+    storage_dir = _expand_path(payload.get("storage_dir", "data"))
+    results_dir = _expand_path(payload.get("results_dir", "out"))
+
+    config = BotConfig(
+        calendar=calendar,
+        whatsapp=whatsapp,
+        players=players,
+        poll_options=poll_options_seq,
+        storage_dir=storage_dir,
+        results_dir=results_dir,
+    )
+    config.ensure_directories()
+    return config
+
+
+__all__ = [
+    "BotConfig",
+    "CalendarConfig",
+    "WhatsAppConfig",
+    "load_config",
+]

--- a/src/participa/poll_manager.py
+++ b/src/participa/poll_manager.py
@@ -1,0 +1,132 @@
+"""Persistence helpers for poll metadata and vote aggregation."""
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, List, Mapping
+
+from .calendar import TrainingEvent
+from .config import BotConfig
+from .whatsapp import PollMessage, PollVote
+
+
+@dataclass(slots=True)
+class StoredPoll:
+    """Poll metadata stored on disk."""
+
+    event_id: str
+    message_id: str
+    question: str
+    options: List[str]
+    start: str
+    end: str
+    location: str | None
+
+    @classmethod
+    def from_event(cls, event: TrainingEvent, poll: PollMessage) -> "StoredPoll":
+        return cls(
+            event_id=event.id,
+            message_id=poll.id,
+            question=poll.question,
+            options=list(poll.options),
+            start=event.start.isoformat(),
+            end=event.end.isoformat(),
+            location=event.location,
+        )
+
+
+class PollStorage:
+    """Utility class for persisting poll metadata."""
+
+    def __init__(self, config: BotConfig) -> None:
+        self._config = config
+
+    def _poll_file(self, date_key: str) -> Path:
+        return self._config.storage_dir / f"polls_{date_key}.json"
+
+    def record_poll(self, event: TrainingEvent, poll: PollMessage) -> None:
+        payload = [asdict(p) for p in self.load_polls(event.start.date())]
+        payload.append(asdict(StoredPoll.from_event(event, poll)))
+        file_path = self._poll_file(event.start.strftime("%Y-%m-%d"))
+        file_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    def load_polls(self, date: dt.date) -> List[StoredPoll]:
+        file_path = self._poll_file(date.strftime("%Y-%m-%d"))
+        if not file_path.exists():
+            return []
+        data = json.loads(file_path.read_text(encoding="utf-8"))
+        polls: List[StoredPoll] = []
+        for entry in data:
+            polls.append(
+                StoredPoll(
+                    event_id=entry["event_id"],
+                    message_id=entry["message_id"],
+                    question=entry["question"],
+                    options=list(entry["options"]),
+                    start=entry["start"],
+                    end=entry["end"],
+                    location=entry.get("location"),
+                )
+            )
+        return polls
+
+
+def aggregate_votes(
+    poll: StoredPoll,
+    votes: Iterable[PollVote],
+    players: Mapping[str, str],
+) -> List[dict]:
+    """Aggregate votes and map them to player names."""
+    results: List[dict] = []
+    for vote in votes:
+        player_name = players.get(vote.voter, vote.voter)
+        results.append(
+            {
+                "player": player_name,
+                "phone": vote.voter,
+                "response": vote.option,
+                "event_id": poll.event_id,
+                "question": poll.question,
+                "start": poll.start,
+                "end": poll.end,
+                "location": poll.location or "",
+            }
+        )
+    return results
+
+
+def export_votes_to_csv(
+    config: BotConfig,
+    date: dt.date,
+    rows: Iterable[dict],
+) -> Path:
+    """Write aggregated rows to a CSV file and return the path."""
+    config.results_dir.mkdir(parents=True, exist_ok=True)
+    file_path = config.results_dir / f"attendance_{date.strftime('%Y%m%d')}.csv"
+    fieldnames = [
+        "player",
+        "phone",
+        "response",
+        "event_id",
+        "question",
+        "start",
+        "end",
+        "location",
+    ]
+    with file_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    return file_path
+
+
+__all__ = [
+    "StoredPoll",
+    "PollStorage",
+    "aggregate_votes",
+    "export_votes_to_csv",
+]

--- a/src/participa/whatsapp.py
+++ b/src/participa/whatsapp.py
@@ -1,0 +1,101 @@
+"""WhatsApp Cloud API helper utilities."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import requests
+
+from .config import BotConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class PollMessage:
+    """Metadata about a poll message posted to WhatsApp."""
+
+    id: str
+    question: str
+    options: List[str]
+
+
+@dataclass(slots=True)
+class PollVote:
+    """A single vote for a poll option."""
+
+    voter: str
+    option: str
+
+
+class WhatsAppPollClient:
+    """Client for sending polls and retrieving vote aggregates."""
+
+    def __init__(self, config: BotConfig) -> None:
+        self._config = config
+        self._base_url = f"https://graph.facebook.com/{config.whatsapp.graph_api_version}"
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {config.whatsapp.token}",
+                "Content-Type": "application/json",
+            }
+        )
+
+    def send_poll(self, question: str, options: Iterable[str]) -> PollMessage:
+        """Send a poll to the configured chat and return the resulting message id."""
+        payload = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": self._config.whatsapp.chat_id,
+            "type": "interactive",
+            "interactive": {
+                "type": "poll",
+                "body": {"text": question},
+                "action": {
+                    "name": "vote",
+                    "parameters": {
+                        "title": question,
+                        "options": list(options),
+                        "allow_multiple_answers": False,
+                    },
+                },
+            },
+        }
+
+        url = f"{self._base_url}/{self._config.whatsapp.phone_number_id}/messages"
+        LOGGER.info("Sending poll to chat %s", self._config.whatsapp.chat_id)
+        response = self._session.post(url, json=payload, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        messages = data.get("messages", [])
+        if not messages:
+            raise RuntimeError("WhatsApp API did not return a message id")
+        message_id = messages[0]["id"]
+        return PollMessage(id=message_id, question=question, options=list(options))
+
+    def fetch_poll_votes(self, poll_message_id: str) -> List[PollVote]:
+        """Fetch poll votes for a given poll message."""
+        params = {
+            "fields": "reactions.limit(100){reaction,actor},votes.limit(100){option_text,selected_options,participant}",
+        }
+        url = f"{self._base_url}/{poll_message_id}"
+        response = self._session.get(url, params=params, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+
+        votes: List[PollVote] = []
+        raw_votes = data.get("votes", {}).get("data", [])
+        for vote in raw_votes:
+            voter = vote.get("participant", {}).get("wa_id")
+            if not voter:
+                continue
+            selected = vote.get("selected_options") or []
+            for option in selected:
+                votes.append(PollVote(voter=voter, option=option.get("text", "")))
+
+        return votes
+
+
+__all__ = ["PollMessage", "PollVote", "WhatsAppPollClient"]


### PR DESCRIPTION
## Summary
- add a configurable WhatsApp attendance bot that posts polls for Google Calendar training events
- persist poll metadata and export daily vote summaries mapped to player names
- document setup steps, provide sample configuration, and declare Python dependencies

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d9895fb00c832a8e2232d0305a0c34